### PR TITLE
Use `zsh` witchcraft to get count of `jj` commits, not shell commands

### DIFF
--- a/dot_p10k.zsh
+++ b/dot_p10k.zsh
@@ -1211,8 +1211,8 @@
     if [[ -n $branch ]]; then
       [[ $branch =~ "\*$" ]] && branch=${branch::-1}
 
-      local VCS_STATUS_COMMITS_AFTER=$(jj --ignore-working-copy --at-op=@ --no-pager log --no-graph -r "$branch..@ & (~empty() | merges())" -T '"n"' 2> /dev/null | wc -c | tr -d ' ')
-      local VCS_STATUS_COMMITS_BEFORE=$(jj --ignore-working-copy --at-op=@ --no-pager log --no-graph -r "@..$branch & (~empty() | merges())" -T '"n"' 2> /dev/null | wc -c | tr -d ' ')
+      local VCS_STATUS_COMMITS_AFTER=${#$(jj --ignore-working-copy --at-op=@ --no-pager log --no-graph -r "$branch..@ & (~empty() | merges())" -T '"n"' 2> /dev/null )}
+      local VCS_STATUS_COMMITS_BEFORE=${#$(jj --ignore-working-copy --at-op=@ --no-pager log --no-graph -r "@..$branch & (~empty() | merges())" -T '"n"' 2> /dev/null )}
       local counts=($(jj --ignore-working-copy --at-op=@ --no-pager bookmark list -r $branch -T '
         if(remote,
           separate(" ",


### PR DESCRIPTION
In my desperate quest to save as many `fork()`s as possible.
